### PR TITLE
Feature/category type validations

### DIFF
--- a/migrations/20191113134949_add_extra_type_to_categories.ts
+++ b/migrations/20191113134949_add_extra_type_to_categories.ts
@@ -1,0 +1,21 @@
+import * as Knex from "knex"
+
+
+export async function up(knex: Knex): Promise<any> {
+  return knex.schema.raw(`
+    ALTER TABLE "categories"
+    DROP CONSTRAINT "categories_type_check",
+    ADD CONSTRAINT "categories_type_check"
+    CHECK (type IN ('TO_USER', 'TO_TWO_USERS', 'TO_USER_WITH_EXTRA', 'ONLY_EXTRA'))
+  `)
+}
+
+export async function down(knex: Knex): Promise<any> {
+  return knex.schema.raw(`
+    ALTER TABLE "categories"
+    DROP CONSTRAINT "categories_type_check",
+    ADD CONSTRAINT "categories_type_check"
+    CHECK (type IN ('TO_USER', 'TO_TWO_USERS', 'ONLY_EXTRA'))
+  `)
+}
+

--- a/src/categories/models.ts
+++ b/src/categories/models.ts
@@ -13,7 +13,7 @@ const CATEGORY_FIELDS = [
   'color'
 ]
 
-export type categoryType = 'TO_USER' | 'TO_TWO_USERS' | 'ONLY_EXTRA';
+export type categoryType = 'TO_USER' | 'TO_TWO_USERS' | 'TO_USER_WITH_EXTRA' | 'ONLY_EXTRA'
 
 export interface CategoryModel {
   id?: number

--- a/src/categories/validations.ts
+++ b/src/categories/validations.ts
@@ -51,7 +51,7 @@ export const categorySchemaValidator = checkSchema({
       }
     },
     isIn: {
-      options: ['TO_USER', 'TO_TWO_USERS', 'ONLY_EXTRA'],
+      options: ['TO_USER', 'TO_USER_WITH_EXTRA', 'TO_TWO_USERS', 'ONLY_EXTRA'],
       errorMessage: 'type.INVALID_VALUE'
     },
   },

--- a/src/nominations/validations.ts
+++ b/src/nominations/validations.ts
@@ -1,5 +1,5 @@
 import { checkSchema } from 'express-validator'
-import { categoryExistsById } from '../categories/models'
+import { categoryExistsById, getCategoryById } from '../categories/models'
 import { existsByUserId } from '../users/models'
 
 export const nominationSchemaValidator = checkSchema({
@@ -15,13 +15,55 @@ export const nominationSchemaValidator = checkSchema({
       errorMessage: 'categoryId.INT'
     },
     custom: {
-      options: async (value) => {
+      options: async (value, { req }) => {
         if (value === undefined || value === null) {
           return Promise.reject('categoryId.MUST_EXIST')
         }
         const exists = await categoryExistsById(value)
         if (!exists) {
           return Promise.reject('categoryId.MUST_EXIST')
+        }
+        const category = await getCategoryById(value)
+        const { mainNominee, auxNominee, extra } = req.body
+        switch (category.type) {
+          case 'ONLY_EXTRA':
+            if (mainNominee !== undefined && mainNominee !== null) {
+              return Promise.reject('categoryId.ONLY_EXTRA.MUST_NOT_HAVE_MAIN_NOMINEE')
+            }
+            if (auxNominee !== undefined && auxNominee !== null) {
+              return Promise.reject('categoryId.ONLY_EXTRA.MUST_NOT_HAVE_AUX_NOMINEE')
+            }
+            if (extra === undefined || extra === null) {
+              return Promise.reject('categoryId.ONLY_EXTRA.MUST_HAVE_EXTRA')
+            }
+            break
+          case 'TO_USER':
+            if (mainNominee === undefined || mainNominee === null) {
+              return Promise.reject('categoryId.TO_USER.MUST_HAVE_MAIN_NOMINEE')
+            }
+            if (auxNominee !== undefined && auxNominee !== null) {
+              return Promise.reject('categoryId.TO_USER.MUST_NOT_HAVE_AUX_NOMINEE')
+            }
+            break
+          case 'TO_TWO_USERS':
+            if (mainNominee === undefined || mainNominee === null) {
+              return Promise.reject('categoryId.TO_USER.MUST_HAVE_MAIN_NOMINEE')
+            }
+            if (auxNominee === undefined || auxNominee === null) {
+              return Promise.reject('categoryId.TO_USER.MUST_HAVE_AUX_NOMINEE')
+            }
+            break
+          case 'TO_USER_WITH_EXTRA':
+            if (mainNominee === undefined || mainNominee === null) {
+              return Promise.reject('categoryId.TO_USER.MUST_HAVE_MAIN_NOMINEE')
+            }
+            if (auxNominee !== undefined && auxNominee !== null) {
+              return Promise.reject('categoryId.TO_USER.MUST_NOT_HAVE_AUX_NOMINEE')
+            }
+            if (extra === undefined || extra === null) {
+              return Promise.reject('categoryId.ONLY_EXTRA.MUST_HAVE_EXTRA')
+            }
+            break
         }
       }
     }
@@ -71,11 +113,11 @@ export const nominationSchemaValidator = checkSchema({
     isLength: {
       errorMessage: 'extra.LENGTH_NOT_VALID',
       options: {
-        min: 7,
+        min: 1,
         max: 255
       }
     },
-  },
+  }
 })
 
 export const nominationLookupSchemaValidator = checkSchema({

--- a/tests/nomination-endpoints/nomination.test.ts
+++ b/tests/nomination-endpoints/nomination.test.ts
@@ -165,6 +165,356 @@ describe('Nomination management', () => {
       expect(nomination.extra).toBe(expected.extra)
     })
 
+    it('Allows nomination creation for a TO_USER category with main nominee and extra', async () => {
+      const nominee = await getUserByStudentId('id-1')
+      await insertCategory({
+        name: 'Test CategoryToUserMNE',
+        type: 'TO_USER',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test CategoryToUserMNE')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        mainNominee: nominee.id,
+        extra: 'test'
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(201)
+    })
+
+    it('Rejects nomination creation for a TO_USER category without main nominee', async () => {
+      await insertCategory({
+        name: 'Test CategoryToUserMN',
+        type: 'TO_USER',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test CategoryToUserMN')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('Rejects nomination creation for a TO_USER category with aux nominee', async () => {
+      const nominee = await getUserByStudentId('id-1')
+      await insertCategory({
+        name: 'Test CategoryToUserAN',
+        type: 'TO_USER',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test CategoryToUserAN')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        auxNominee: nominee.id
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('Allows nomination creation for a TO_TWO_USERS category with main nominee and aux nominee', async () => {
+      const nominee = await getUserByStudentId('id-1')
+      const nominee2 = await getUserByStudentId('id-2')
+      await insertCategory({
+        name: 'Test Category2usersMA',
+        type: 'TO_TWO_USERS',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test Category2usersMA')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        mainNominee: nominee.id,
+        auxNominee: nominee2.id
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(201)
+    })
+
+    it('Allows nomination creation for a TO_TWO_USERS category with main nominee and aux nominee and extra', async () => {
+      const nominee = await getUserByStudentId('id-1')
+      const nominee2 = await getUserByStudentId('id-2')
+      await insertCategory({
+        name: 'Test Category2usersMAE',
+        type: 'TO_TWO_USERS',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test Category2usersMAE')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        mainNominee: nominee.id,
+        auxNominee: nominee2.id,
+        extra: 'test'
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(201)
+    })
+
+    it('Rejects nomination creation for a TO_TWO_USERS category with main nominee and without aux nominee', async () => {
+      const nominee = await getUserByStudentId('id-1')
+      await insertCategory({
+        name: 'Test Category2usersFail1',
+        type: 'TO_TWO_USERS',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test Category2usersFail1')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        mainNominee: nominee.id,
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('Rejects nomination creation for a TO_TWO_USERS category without main nominee and with aux nominee', async () => {
+      const nominee = await getUserByStudentId('id-1')
+      await insertCategory({
+        name: 'Test Category2usersFail2',
+        type: 'TO_TWO_USERS',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test Category2usersFail2')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        auxNominee: nominee.id,
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('Rejects nomination creation for a TO_TWO_USERS category with only extra', async () => {
+      await insertCategory({
+        name: 'Test Category2usersFail3',
+        type: 'TO_TWO_USERS',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test Category2usersFail3')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        extra: 'test1'
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('Allows nomination creation for a ONLY_EXTRA category with only extra', async () => {
+      await insertCategory({
+        name: 'Test CategoryExtraGood',
+        type: 'ONLY_EXTRA',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test CategoryExtraGood')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        extra: 'yummy yummy'
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(201)
+    })
+
+    it('Rejects nomination creation for a ONLY_EXTRA category without extra', async () => {
+      const nominee = await getUserByStudentId('id-1')
+      await insertCategory({
+        name: 'Test CategoryExtra',
+        type: 'ONLY_EXTRA',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test CategoryExtra')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        mainNominee: nominee.id
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('Rejects nomination creation for a ONLY_EXTRA category with main nominee', async () => {
+      const nominee = await getUserByStudentId('id-1')
+      await insertCategory({
+        name: 'Test CategoryExtraMainNominee',
+        type: 'ONLY_EXTRA',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test CategoryExtraMainNominee')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        extra: 'test extra',
+        mainNominee: nominee.id
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('Rejects nomination creation for a ONLY_EXTRA category with aux nominee', async () => {
+      const nominee = await getUserByStudentId('id-1')
+      await insertCategory({
+        name: 'Test CategoryExtraAuxNominee',
+        type: 'ONLY_EXTRA',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test CategoryExtraAuxNominee')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        extra: 'test extra',
+        auxNominee: nominee.id
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('Allows nomination creation for a TO_USER_WITH_EXTRA category with main nominee and extra', async () => {
+      const nominee = await getUserByStudentId('id-1')
+      await insertCategory({
+        name: 'Test touserextraMNE',
+        type: 'TO_USER_WITH_EXTRA',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test touserextraMNE')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        mainNominee: nominee.id,
+        extra: 'test'
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(201)
+    })
+
+    it('Rejects nomination creation for a TO_USER_WITH_EXTRA category with aux nominee and extra', async () => {
+      const nominee = await getUserByStudentId('id-1')
+      await insertCategory({
+        name: 'Test touserextraMNE2',
+        type: 'TO_USER_WITH_EXTRA',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test touserextraMNE2')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        auxNominee: nominee.id,
+        extra: 'test'
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(400)
+    })
+
+    it('Rejects nomination creation for a TO_USER_WITH_EXTRA category without main nominee', async () => {
+      await insertCategory({
+        name: 'Test touserextraMNE3',
+        type: 'TO_USER_WITH_EXTRA',
+        pictureUrl: 'http://google.com',
+        description: 'Sample description',
+        extra: 'Extra information',
+        color: '#000000'
+      })
+      const category = await getCategoryByName('Test touserextraMNE3')
+      const expected : CreateNominationRequest = {
+        categoryId: category.id,
+        extra: 'test'
+      }
+
+      const res = await request(app)
+        .post(url)
+        .send(expected)
+        .set('Authorization', `Bearer ${NON_ADMIN_TOKEN}`)
+      expect(res.status).toBe(400)
+    })
+
     it('Rejects nomination creation with no authorization', async () => {
       const nominee = await getUserByStudentId('id-1')
       await insertCategory({


### PR DESCRIPTION
This PR adds:

- A new Category Type, with its respective migration: TO_USER_WITH_EXTRA, for categories that require both a main nominee and an extra (e.g. CompuCartoon)
- A series of new validations for nominations according to their category type
- A new batch of tests